### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Node.js library for beez and beez-founation with beez-tools.
         - 画像サイズ取得
         - ファイル名のpixelRatioから、それ以外のpixelRatio画像をリサイズ
 - fsys
-    - ファイルのタイプを判定(file, directory, block device, charactor device, symlink, fifo, socket)
+    - ファイルのタイプを判定(file, directory, block device, character device, symlink, fifo, socket)
     - rm -rf (sync) : フォルダ削除
     - mkdir -p (async|sync) : フォルダ作成
     - glob : フォルダ内を走査


### PR DESCRIPTION
@CyberAgent, I've corrected a typographical error in the documentation of the [beezlib](https://github.com/CyberAgent/beezlib) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
